### PR TITLE
Fix antenna EC calculation typo

### DIFF
--- a/GameData/KerbalismConfig/System/ScienceRework/Patches-Antennas.cfg
+++ b/GameData/KerbalismConfig/System/ScienceRework/Patches-Antennas.cfg
@@ -68,7 +68,7 @@
 
 @PART[*]:HAS[@MODULE[ModuleDataTransmitter*]:HAS[#antennaType[DIRECT]]]:NEEDS[FeatureScience,!RemoteTech]:BEFORE[zzzKerbalismDefault]
 {
-	@MODULE[ModuleDataTransmitter]:HAS[#antennaType[DIRECT]] { @packetResourceCost /= 7}
+	@MODULE[ModuleDataTransmitter*]:HAS[#antennaType[DIRECT]] { @packetResourceCost /= 7}
 }
 
 @PART[*]:HAS[@MODULE[ModuleDataTransmitter*]:HAS[#antennaType[RELAY]]]:NEEDS[FeatureScience,!RemoteTech]:BEFORE[zzzKerbalismDefault]


### PR DESCRIPTION
A typo meant that some antennas, for example feedable antennas from Near Future Exploration had too much EC consumption.